### PR TITLE
Fix: Missing cargo.toml information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,14 @@
 [package]
 name = "wdi"
+description = "Rust library for interacting with the Windows Driver Installer subsystem."
 version = "0.1.0"
+license = "MIT or Apache-2.0"
+repository = "https://github.com/blackmagic-debug/wdi-rs"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = []
 
 [dependencies]
 libwdi-sys = { path = "libwdi-sys" }

--- a/libwdi-sys/Cargo.toml
+++ b/libwdi-sys/Cargo.toml
@@ -1,10 +1,16 @@
 [package]
 name = "libwdi-sys"
+description = "FFI bindings for libwdi."
 version = "0.1.0"
+license = "MIT or Apache-2.0"
+repository = "https://github.com/blackmagic-debug/wdi-rs"
 edition = "2021"
 links = "wdi"
+categories = ["os::windows-apis"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[package.metadata.docs.rs]
+default-target = "x86_64-pc-windows-msvc"
+targets = []
 
 [features]
 # Run bindgen at build time instead of using the already-generated bindings. Requires libclang on the system.


### PR DESCRIPTION
In this PR we add various keys that were missing from the crate cargo.toml's to finish preparing the project for crates.io publication - with this merged, we should be good to go for publishing.