### PR TITLE
Added option to disable ARM64 and x86 targets

### DIFF
--- a/libwdi-sys/Cargo.toml
+++ b/libwdi-sys/Cargo.toml
@@ -15,7 +15,10 @@ targets = []
 [features]
 # Run bindgen at build time instead of using the already-generated bindings. Requires libclang on the system.
 dynamic-bindgen = []
+# Disable ARM64 target compilation
 disable-arm64 = []
+# Disable x86 (32-bit) target compilation
+disable-x86 = []
 
 [build-dependencies]
 bindgen = "0.66.1"

--- a/libwdi-sys/Cargo.toml
+++ b/libwdi-sys/Cargo.toml
@@ -15,6 +15,7 @@ targets = []
 [features]
 # Run bindgen at build time instead of using the already-generated bindings. Requires libclang on the system.
 dynamic-bindgen = []
+make-installer-arm64 = []
 
 [build-dependencies]
 bindgen = "0.66.1"

--- a/libwdi-sys/Cargo.toml
+++ b/libwdi-sys/Cargo.toml
@@ -15,7 +15,7 @@ targets = []
 [features]
 # Run bindgen at build time instead of using the already-generated bindings. Requires libclang on the system.
 dynamic-bindgen = []
-make-installer-arm64 = []
+disable-arm64 = []
 
 [build-dependencies]
 bindgen = "0.66.1"

--- a/libwdi-sys/build.rs
+++ b/libwdi-sys/build.rs
@@ -712,7 +712,9 @@ fn main()
     build.populate_source_tree();
     build.make_embedder();
     build.make_installer_x86_64();
-    build.make_installer_arm64();
+    if cfg!(feature = "make-installer-arm64") {
+        build.make_installer_arm64();
+    }
     build.run_embedder();
     build.make_lib();
 

--- a/libwdi-sys/build.rs
+++ b/libwdi-sys/build.rs
@@ -712,7 +712,7 @@ fn main()
     build.populate_source_tree();
     build.make_embedder();
     build.make_installer_x86_64();
-    if cfg!(feature = "make-installer-arm64") {
+    if !cfg!(feature = "disable-arm64") {
         build.make_installer_arm64();
     }
     build.run_embedder();


### PR DESCRIPTION
I needed option to disable ARM64 compilation so I've added these two features:
```
# Disable ARM64 target compilation
disable-arm64 = []
# Disable x86 (32-bit) target compilation
disable-x86 = []
```

Usage - Cargo.toml: 
```
libwdi-sys = { version = "0.1", features = ["disable-arm64", "disable-x86"] }
```